### PR TITLE
Fix layout of badges

### DIFF
--- a/_layouts/badges.html
+++ b/_layouts/badges.html
@@ -8,19 +8,23 @@
     <title>Software Carpentry{% if page.title %}: {{page.title}}{% endif %}</title>
   </head>
   <body>
-    {% include navbar.html %}
-    <div class="container">
-      <div class="row-fluid">
-        <div class="span10 offset1">
-          {% if page.title %}
+    <header class="header">
+      {% include navbar.html %}
+    </header>
+    {% if page.title %}
+    <section id="title" class="content">
+        <div class="container">
             <h1 class="title">{{page.title}}</h1>
-          {% endif %}
-          {{content}}
-          {% include disqus.html %}
-          {% include footer.html %}
         </div>
+    </section>
+    {% endif %}
+    <section class="content">
+      <div class="container">
+          {{content}}
       </div>
-    </div>
+    </section>
+    {% include disqus.html %}
+    {% include footer.html %}
 
     <!-- attach actions -->
     <script src="http://beta.openbadges.org/issuer.js"></script>


### PR DESCRIPTION
The window on the left is the one with this patch and the window of the right is same page at the website (**without this patch**),

![s](https://cloud.githubusercontent.com/assets/1506457/5885121/123a45dc-a34e-11e4-8900-7f0b8cc72eee.jpg)
